### PR TITLE
18F site redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -75,7 +75,7 @@ http {
   server {
     listen <%= ENV["PORT"] %>;
     server_name join.18f.gov;
-    return 302 https://18f.gsa.gov/join-18f/;
+    return 302 https://18f.gsa.gov/join/;
   }
 
   server {
@@ -85,7 +85,7 @@ http {
     rewrite ^/intake/.* https://18f.gsa.gov/contact/ redirect;
     rewrite ^/designstandards/.* https://standards.usa.gov/ redirect;
     rewrite ^/pages/.* https://github.com/18F/pages/ redirect;
-    rewrite ^/joining-18f/.* https://18f.gsa.gov/join-18f/ redirect;
+    rewrite ^/joining-18f/.* https://18f.gsa.gov/join/ redirect;
     rewrite ^/$ /guides/ redirect;
     rewrite ^/([^/]*)$ /$1/ redirect;
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,16 +75,17 @@ http {
   server {
     listen <%= ENV["PORT"] %>;
     server_name join.18f.gov;
-    return 302 https://pages.18f.gov/joining-18f/;
+    return 302 https://18f.gsa.gov/join-18f/;
   }
 
   server {
     listen <%= ENV["PORT"] %>;
     server_name guides.18f.gov pages.18f.gov;
     rewrite ^/state-faq/.* https://modularcontracting.18f.gov/ redirect;
-    rewrite ^/intake/.* https://18f.gsa.gov/hire/ redirect;
+    rewrite ^/intake/.* https://18f.gsa.gov/contact/ redirect;
     rewrite ^/designstandards/.* https://standards.usa.gov/ redirect;
     rewrite ^/pages/.* https://github.com/18F/pages/ redirect;
+    rewrite ^/joining-18f/.* https://18f.gsa.gov/join-18f/ redirect;
     rewrite ^/$ /guides/ redirect;
     rewrite ^/([^/]*)$ /$1/ redirect;
     location / {


### PR DESCRIPTION
For https://github.com/18F/18f.gsa.gov/issues/2340

This updates a few redirects [18f.gsa.gov](https://18f.gsa.gov):
* [join.18f.gov](https://join.18f.gov/) --> [18f.gsa.gov/join/](https://18f.gsa.gov/join/) 
  - **_(currently not getting to the right endpoint)_**
* [pages.18f.gov/joining-18f/](https://pages.18f.gov/joining-18f/) --> [18f.gsa.gov/join/](https://18f.gsa.gov/join/) 
  - **_(currently not getting to the right endpoint)_**
*  [pages.18f.gov/intake/](https://pages.18f.gov/intake/) --> [18f.gsa.gov/contact/](https://18f.gsa.gov/contact/)
   - **_(currently being redirected to an old page and being redirected to the right page via HTML refresh)_**
*  [guides.18f.gov/intake/](https://guides.18f.gov/intake/) --> [18f.gsa.gov/contact/](https://18f.gsa.gov/contact/)
   - **_(currently being redirected to an old page and being redirected to the right page via HTML refresh)_**